### PR TITLE
feat: extend slackbot api

### DIFF
--- a/apps/slackbot-api/src/app/controllers/webhook.controller.ts
+++ b/apps/slackbot-api/src/app/controllers/webhook.controller.ts
@@ -3,7 +3,7 @@ import { Body, Controller, HttpCode, Post, Res } from '@nestjs/common';
 import { WebClient, LogLevel } from '@slack/web-api';
 import { SLACK_OAUTH_ACCESS_TOKEN, SLACK_DEDICATED_CHANNEL } from '../core/config';
 
-import { formatKroepnLeaderboardRow, PlayerService, parseSlackUser, Callback, IOption } from '@foosball/api/common';
+import { formatKroepnLeaderboardRow, PlayerService, parseSlackUser, Callback, IOption, MatchService } from '@foosball/api/common';
 import { DataService } from '@foosball/api/data';
 import { DateTime } from 'luxon';
 import { SlackHelper, addViewedBySnippetToBlock } from '../core/utils';
@@ -15,7 +15,11 @@ import { Response } from 'express';
 export class WebhookController {
   private client: WebClient;
 
-  constructor(private readonly data: DataService, private readonly playerService: PlayerService) {
+  constructor(
+    private readonly data: DataService,
+    private readonly playerService: PlayerService,
+    private readonly matchService: MatchService
+  ) {
     this.client = new WebClient(SLACK_OAUTH_ACCESS_TOKEN, {
       // logLevel: LogLevel.DEBUG,
     });
@@ -260,7 +264,7 @@ export class WebhookController {
         console.log('[interactive] Add match result', { homeTeam, awayTeam, finalScore });
 
         // const matchService = new MatchService(Firestore.db);
-        // await this.matchService.addSimpleMatchResult(homeTeam, awayTeam, finalScore);
+        await this.matchService.addSimpleMatchResult(homeTeam, awayTeam, finalScore);
 
         const players = await this.playerService.getPlayersById([...homeTeam, ...awayTeam]);
 

--- a/apps/slackbot-api/src/app/controllers/webhook.controller.ts
+++ b/apps/slackbot-api/src/app/controllers/webhook.controller.ts
@@ -1,13 +1,14 @@
 import { Body, Controller, Post } from '@nestjs/common';
 
 import { WebClient } from '@slack/web-api';
-import { SLACK_OAUTH_ACCESS_TOKEN } from '../core/config';
+import { SLACK_OAUTH_ACCESS_TOKEN, SLACK_DEDICATED_CHANNEL } from '../core/config';
 
-import { formatKroepnLeaderboardRow, PlayerService, parseSlackUser } from '@foosball/api/common';
+import { formatKroepnLeaderboardRow, PlayerService, parseSlackUser, Callback } from '@foosball/api/common';
 import { DataService } from '@foosball/api/data';
 import { DateTime } from 'luxon';
 import { SlackHelper, addViewedBySnippetToBlock } from '../core/utils';
 import { getPlayerCard } from '../views/slack';
+import { IFinalScore } from '@foosball/dto';
 
 @Controller('')
 export class WebhookController {
@@ -41,7 +42,7 @@ export class WebhookController {
       case 'update-me':
       case 'um':
         console.log('Run cmd: update-me');
-        return this.runFoosballCommand();
+        return this.runUpdateMeCommand(slackRequest);
 
       default:
         console.log('Run cmd: leaderboard');
@@ -57,10 +58,52 @@ export class WebhookController {
   }
 
   @Post('update-me')
-  async runUpdateMeCommand() {
-    return {
-      text: 'Sorry, this command will be back soon.',
-    };
+  async runUpdateMeCommand(@Body() input: any) {
+    const payload = input;
+    console.log('[update-me] Received', payload);
+
+    // await SlackHelper.acknowledge();
+    // console.log('[update-me] Event Acknowledged');
+
+    const { user_id } = payload;
+    const player = await this.playerService.getPlayerBySlackId(user_id);
+
+    await this.client.dialog.open({
+      trigger_id: payload.trigger_id,
+      dialog: {
+        callback_id: Callback.UPDATE_ME,
+        title: 'Profile',
+        submit_label: 'Save',
+        notify_on_cancel: true,
+        elements: [
+          {
+            label: 'Nickname',
+            name: 'nickname',
+            type: 'text',
+            placeholder: 'Your nickname...',
+            value: player.nickname,
+            optional: true,
+          },
+          {
+            label: 'Status',
+            name: 'status',
+            type: 'text',
+            placeholder: 'Your status...',
+            value: player.status,
+            optional: true,
+          },
+          {
+            label: 'Quote',
+            name: 'quote',
+            type: 'text',
+            placeholder: 'Your quote...',
+            value: player.quote,
+            optional: true,
+          },
+        ],
+      },
+    });
+    // console.log('[update-me] Dialog sent');
   }
 
   @Post('kroepn-leaderboard')
@@ -113,5 +156,74 @@ export class WebhookController {
       console.log('[player-card] Error', e);
       return;
     }
+  }
+
+  @Post('interactive')
+  async interactiveCallback(@Body() input: any) {
+    const payload = input; // JSON.parse(req.body.payload);
+    console.log('[interactive] Received', payload);
+
+    const { user, submission, callback_id } = payload;
+
+    // const playerService = new PlayerService(Firestore.db);
+    switch (callback_id) {
+      case Callback.FOOSBALL_MATCH:
+        const { team1player1, team1player2, team2player1, team2player2, score1, score2 } = submission;
+        const errors = [];
+        if (isNaN(score1)) {
+          errors.push({
+            name: 'score1',
+            error: "Sorry, that ain't a number",
+          });
+        }
+        if (isNaN(score2)) {
+          errors.push({
+            name: 'score2',
+            error: "Sorry, that ain't a number",
+          });
+        }
+        if (errors.length) {
+          // Return with error messages
+          // return SlackHelper.send(res, { errors });
+          return { errors };
+        }
+
+        // Send ACK, to prevent time-out
+        // SlackHelper.acknowledge(res);
+
+        const homeTeam = [team1player1];
+        if (team1player2) homeTeam.push(team1player2);
+        const awayTeam = [team2player1];
+        if (team2player2) awayTeam.push(team2player2);
+        const finalScore: IFinalScore = [parseInt(score1), parseInt(score2)];
+
+        console.log('[interactive] Add match result', { homeTeam, awayTeam, finalScore });
+
+        // const matchService = new MatchService(Firestore.db);
+        // await this.matchService.addSimpleMatchResult(homeTeam, awayTeam, finalScore);
+
+        const players = await this.playerService.getPlayersById([...homeTeam, ...awayTeam]);
+
+        const homeTeamString = SlackHelper.concatPlayersString(homeTeam, players);
+        const awayTeamString = SlackHelper.concatPlayersString(awayTeam, players);
+
+        return this.client.chat.postMessage({
+          channel: SLACK_DEDICATED_CHANNEL || payload.channel.id,
+          text: SlackHelper.buildMatchResultString(homeTeamString, awayTeamString, finalScore),
+        });
+      case Callback.UPDATE_ME:
+        const { nickname, status, quote } = submission;
+
+        const player = await this.playerService.getPlayerBySlackId(user.id);
+        await this.playerService.updatePlayer(player.id, { nickname, status, quote });
+        // await SlackHelper.acknowledge();
+        return this.client.chat.postEphemeral({
+          user: user.id,
+          channel: payload.channel.id,
+          text: SlackHelper.buildUpdateProfileString(player),
+        });
+      // break;
+    }
+    return SlackHelper.acknowledge();
   }
 }

--- a/apps/slackbot-api/src/app/controllers/webhook.controller.ts
+++ b/apps/slackbot-api/src/app/controllers/webhook.controller.ts
@@ -231,7 +231,7 @@ export class WebhookController {
     const { user, submission, callback_id } = payload;
 
     switch (callback_id) {
-      case Callback.FOOSBALL_MATCH:
+      case Callback.FOOSBALL_MATCH: {
         const { team1player1, team1player2, team2player1, team2player2, score1, score2 } = submission;
         const errors = [];
         if (isNaN(score1)) {
@@ -275,7 +275,8 @@ export class WebhookController {
           channel: SLACK_DEDICATED_CHANNEL || payload.channel.id,
           text: SlackHelper.buildMatchResultString(homeTeamString, awayTeamString, finalScore),
         });
-      case Callback.UPDATE_ME:
+      }
+      case Callback.UPDATE_ME: {
         const { nickname, status, quote } = submission;
 
         const player = await this.playerService.getPlayerBySlackId(user.id);
@@ -289,6 +290,7 @@ export class WebhookController {
           channel: payload.channel.id,
           text: SlackHelper.buildUpdateProfileString(player),
         });
+      }
     }
   }
   @Post('options-load-endpoint')
@@ -303,13 +305,14 @@ export class WebhookController {
     const options: IOption[] = [];
 
     switch (callback_id) {
-      case Callback.FOOSBALL_MATCH:
+      case Callback.FOOSBALL_MATCH: {
         const playerOptions = await SlackHelper.getExternalDataOptions(this.playerService, 'players');
         const filteredPlayerOptions = playerOptions.filter(
           (option: IOption) => option.label.toLowerCase().indexOf(value.toLowerCase()) >= 0
         );
         options.push(...filteredPlayerOptions);
         break;
+      }
     }
     return SlackHelper.send(response, {
       options,

--- a/apps/slackbot-api/src/app/core/utils/add-viewed-by-snippet-to-block.util.ts
+++ b/apps/slackbot-api/src/app/core/utils/add-viewed-by-snippet-to-block.util.ts
@@ -1,0 +1,19 @@
+export function addViewedBySnippetToBlock(blocks: any[], slackUserId: string): any[] {
+  if (!slackUserId) {
+    return blocks;
+  }
+  const response = [
+    ...blocks,
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `Requested by <@${slackUserId}>`,
+        },
+      ],
+    },
+  ];
+  console.log('addViewedBySnippetToBlock', response);
+  return response;
+}

--- a/apps/slackbot-api/src/app/core/utils/index.ts
+++ b/apps/slackbot-api/src/app/core/utils/index.ts
@@ -1,2 +1,2 @@
 export { SlackHelper } from './slack-helper.utils';
-export { addViewedBySnippetToBlock } from './slack-helper.utils';
+export { addViewedBySnippetToBlock } from './add-viewed-by-snippet-to-block.util';

--- a/apps/slackbot-api/src/app/core/utils/slack-helper.utils.ts
+++ b/apps/slackbot-api/src/app/core/utils/slack-helper.utils.ts
@@ -135,24 +135,3 @@ function applyFilter(items: Player[], filter: IDefaultLeaderboardOpts): Player[]
 
   return result;
 }
-
-// TODO: refactor into SlackApi -> Core
-export function addViewedBySnippetToBlock(blocks: any[], slackUserId: string): any[] {
-  if (!slackUserId) {
-    return blocks;
-  }
-  const response = [
-    ...blocks,
-    {
-      type: 'context',
-      elements: [
-        {
-          type: 'mrkdwn',
-          text: `Requested by <@${slackUserId}>`,
-        },
-      ],
-    },
-  ];
-  console.log('addViewedBySnippetToBlock', response);
-  return response;
-}

--- a/apps/slackbot-api/src/app/core/utils/slack-helper.utils.ts
+++ b/apps/slackbot-api/src/app/core/utils/slack-helper.utils.ts
@@ -10,9 +10,12 @@ interface IDefaultLeaderboardOpts {
 }
 
 export class SlackHelper {
-  static async acknowledge(res?: Response | any) {
-    console.log('[player-card] Event Acknowledged');
-    console.debug(`SlackHelper.acknowledge isn't implemented properly.`);
+  static async acknowledge(res?: Response | any, body?: any) {
+    if (!res) {
+      return;
+    }
+
+    return this.send(res, body);
   }
 
   static async send(res: Response, body?: any): Promise<Response> {

--- a/apps/slackbot-api/tsconfig.json
+++ b/apps/slackbot-api/tsconfig.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "strict": false,
     "noImplicitReturns": false,
+    "noImplicitAny": false,
     "noFallthroughCasesInSwitch": true
   }
 }

--- a/libs/api-core/common/src/lib/services/player.service.ts
+++ b/libs/api-core/common/src/lib/services/player.service.ts
@@ -59,6 +59,15 @@ export class PlayerService extends CoreService {
   }
 
   async updatePlayer(id: string, { name, nickname, avatar, slackId, status, quote }: Partial<Player>): Promise<void> {
+    console.log('updatePlayer', {
+      id,
+      name,
+      nickname,
+      avatar,
+      slackId,
+      status,
+      quote,
+    });
     if (!id) {
       throw Error('id  is null');
     }

--- a/libs/api-core/core/src/lib/core.module.ts
+++ b/libs/api-core/core/src/lib/core.module.ts
@@ -18,7 +18,7 @@ import { join } from 'path';
     GraphQLModule.forRoot({
       playground: false,
       plugins: [ApolloServerPluginLandingPageLocalDefault()],
-      autoSchemaFile: join(process.cwd(), 'libs/foosball/core/src/schema.gql'),
+      autoSchemaFile: join(process.cwd(), 'libs/api-core/core/src/schema.gql'),
     }),
   ],
   controllers: [],

--- a/libs/foosball/core/src/schema.gql
+++ b/libs/foosball/core/src/schema.gql
@@ -1,7 +1,0 @@
-# ------------------------------------------------------
-# THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
-# ------------------------------------------------------
-
-type Query {
-  uptime: Float!
-}


### PR DESCRIPTION
- add support for updating profile (via Slack)
- add support for logging a match (via Slack)
- fixed Slack interactive endpoints