### PR TITLE
ci: change dependabot's update schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@ updates:
   - package-ecosystem: 'npm'
     directory: .
     schedule:
-      # Check the npm registry for updates at 4am UTC
-      interval: 'daily'
+      # Check the npm registry for updates every Sunday at 4am UTC
+      interval: 'weekly'
+      day: 'sunday'
       time: '04:00'
     open-pull-requests-limit: 20
     target-branch: 'main'


### PR DESCRIPTION
For this repo, I think it's fine to refresh the dependencies on a weekly basis.