### PR TITLE
feat: add seeder for matches

### DIFF
--- a/libs/database-seeds/src/lib/data/matches.json
+++ b/libs/database-seeds/src/lib/data/matches.json
@@ -1,0 +1,36 @@
+{
+  "matches": [
+    {
+      "toto": 1,
+      "matchDate": "2024-01-10T14:51:30.274Z",
+      "finalScore": [10, 4],
+      "homeTeamIds": ["user.one@example.com", "user.two@example.com"],
+      "awayTeamIds": ["user.three@example.com", "user.four@example.com"],
+      "homeTeam": [
+        {
+          "id": "user.one@example.com",
+          "name": "User One",
+          "avatar": "https://example.com/avatar1.jpg"
+        },
+        {
+          "id": "user.two@example.com",
+          "name": "User Two",
+          "avatar": "https://example.com/avatar2.jpg"
+        }
+      ],
+      "awayTeam": [
+        {
+          "id": "user.three@example.com",
+          "name": "User Three",
+          "avatar": "https://example.com/avatar3.jpg"
+        },
+        {
+          "id": "user.four@example.com",
+          "name": "User Four",
+          "avatar": "https://example.com/avatar4.jpg"
+        }
+      ],
+      "creationDate": "2024-01-10T14:51:30.461Z"
+    }
+  ]
+}

--- a/libs/database-seeds/src/lib/seeders/match.seeder.ts
+++ b/libs/database-seeds/src/lib/seeders/match.seeder.ts
@@ -1,0 +1,31 @@
+import { Firestore } from 'firebase-admin/firestore';
+import { Seeder } from '../types/seeder.interface';
+import { IMatchResult } from '@foosball/common';
+
+export class MatchSeeder implements Seeder<IMatchResult> {
+  async seed(db: Firestore, matches: IMatchResult[]): Promise<void> {
+    const batch = db.batch();
+
+    for (const match of matches) {
+      const matchId = db.collection('matches').doc().id;
+      const ref = db.collection('matches').doc(matchId);
+      batch.set(ref, {
+        ...match,
+        id: matchId,
+      });
+    }
+
+    await batch.commit();
+  }
+
+  async clear(db: Firestore): Promise<void> {
+    const snapshot = await db.collection('matches').get();
+    const batch = db.batch();
+
+    snapshot.docs.forEach(doc => {
+      batch.delete(doc.ref);
+    });
+
+    await batch.commit();
+  }
+}

--- a/libs/database-seeds/src/main.ts
+++ b/libs/database-seeds/src/main.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { PlayerSeeder } from './lib/seeders/player.seeder';
+import { MatchSeeder } from './lib/seeders/match.seeder';
 import { loadJsonData } from './lib/utils/file-loader';
 
 async function main() {
@@ -25,10 +26,15 @@ async function main() {
 
   try {
     const playerSeeder = new PlayerSeeder();
+    const matchSeeder = new MatchSeeder();
 
     // Seed players first
     const playerData = await loadJsonData<{ players: any[] }>('players.json');
     await playerSeeder.seed(db, playerData.players);
+
+    // Seed matches next
+    const matchData = await loadJsonData<{ matches: any[] }>('matches.json');
+    await matchSeeder.seed(db, matchData.matches);
 
     console.log('✅ Seeding completed');
     process.exit(0);


### PR DESCRIPTION
This pull request introduces the functionality to seed match data into the Firestore database. The most important changes include the addition of a new JSON file containing match data, the implementation of a `MatchSeeder` class to handle seeding operations, and modifications to the main seeding script to incorporate the new match seeding process.

Changes related to match data seeding:

* [`libs/database-seeds/src/lib/data/matches.json`](diffhunk://#diff-99bd4b03ebe29459b269b7d939cac577cc818f71fff350b96416981533219dbdR1-R36): Added a new JSON file containing match data, including details such as match date, final score, team members, and creation date.
* [`libs/database-seeds/src/lib/seeders/match.seeder.ts`](diffhunk://#diff-456c5b509b8c13fb68d6f0b5cc914c061811a5af2a0726f742b755e9783e9c61R1-R31): Implemented the `MatchSeeder` class with methods for seeding and clearing match data in Firestore.

Modifications to main seeding script:

* [`libs/database-seeds/src/main.ts`](diffhunk://#diff-765c628c8e5bb29b40bb0fde71807cc91418b14dac1ae0c7491505373a86ad1bR4): Imported the `MatchSeeder` class and updated the main function to seed match data after seeding player data. [[1]](diffhunk://#diff-765c628c8e5bb29b40bb0fde71807cc91418b14dac1ae0c7491505373a86ad1bR4) [[2]](diffhunk://#diff-765c628c8e5bb29b40bb0fde71807cc91418b14dac1ae0c7491505373a86ad1bR29-R38)