### PR TITLE
feat: extend player stats with goalsFor and goalsAgainst

### DIFF
--- a/apps/sandbox/src/triggers/backfill-goals-stats.trigger.ts
+++ b/apps/sandbox/src/triggers/backfill-goals-stats.trigger.ts
@@ -1,0 +1,193 @@
+import { QueryDocumentSnapshot, WriteBatch, getFirestore } from 'firebase-admin/firestore';
+import * as logger from 'firebase-functions/logger';
+import { HttpsOptions, onRequest } from 'firebase-functions/v2/https';
+
+import { IMatchResult } from '@foosball/common';
+
+// --- Configuration ---
+const DEFAULT_REGION = 'europe-west1';
+const MATCH_FETCH_LIMIT = 500;
+const WRITE_BATCH_LIMIT = 450;
+const PLAYERS_COLLECTION = 'players';
+const MATCHES_COLLECTION = 'matches';
+// --- End Configuration ---
+
+// --- Helper Functions ---
+interface IPlayerGoalsAggregate {
+  totalGoalsFor: number;
+  totalGoalsAgainst: number;
+  lastMatchDate?: string;
+}
+
+function calculatePlayerGoals(playerId: string, matchResult: IMatchResult): { goalsFor: number; goalsAgainst: number } {
+  const playerTeamIndex = matchResult.homeTeamIds.includes(playerId) ? 0 : 1;
+  const goalsFor = typeof matchResult.finalScore[playerTeamIndex] === 'number' ? matchResult.finalScore[playerTeamIndex] : 0;
+  const goalsAgainst =
+    typeof matchResult.finalScore[playerTeamIndex === 0 ? 1 : 0] === 'number' ? matchResult.finalScore[playerTeamIndex === 0 ? 1 : 0] : 0;
+
+  return { goalsFor, goalsAgainst };
+}
+
+async function writeGoalStatsToFirestore(
+  db: FirebaseFirestore.Firestore,
+  playerStats: { [playerId: string]: IPlayerGoalsAggregate }
+): Promise<number> {
+  let currentBatch: WriteBatch = db.batch();
+  let batchOpsCount = 0;
+  let totalWrites = 0;
+  const writePromises: Promise<any>[] = [];
+
+  const commitBatchIfNeeded = async () => {
+    if (batchOpsCount > 0) {
+      logger.info(`Committing batch with ${batchOpsCount} operations...`);
+      writePromises.push(currentBatch.commit());
+      totalWrites += batchOpsCount;
+      currentBatch = db.batch();
+      batchOpsCount = 0;
+      await new Promise(resolve => setTimeout(resolve, 100)); // Simple delay
+    }
+  };
+
+  for (const playerId in playerStats) {
+    const stats = playerStats[playerId];
+    const docRef = db.collection(PLAYERS_COLLECTION).doc(playerId);
+
+    currentBatch.update(docRef, {
+      totalGoalsFor: stats.totalGoalsFor,
+      totalGoalsAgainst: stats.totalGoalsAgainst,
+      lastMatchDate: stats.lastMatchDate,
+    });
+
+    batchOpsCount++;
+    if (batchOpsCount >= WRITE_BATCH_LIMIT) {
+      await commitBatchIfNeeded();
+    }
+  }
+
+  await commitBatchIfNeeded(); // Commit final batch
+  await Promise.all(writePromises);
+  logger.info(`Firestore writes complete. Total documents updated: ${totalWrites}`);
+  return totalWrites;
+}
+
+// --- Cloud Function Definition ---
+const functionOptions: HttpsOptions = {
+  region: DEFAULT_REGION,
+  timeoutSeconds: 3600, // 60 minutes (max for v2)
+  memory: '1GiB',
+};
+
+export const backfillGoalsStats = onRequest(functionOptions, async (req, res): Promise<void> => {
+  logger.info('Received request to backfill player goals stats.', { query: req.query });
+
+  // --- Security Check ---
+  const secret = process.env.BACKFILL_SECRET || 'dev-secret';
+  if (req.query.secret !== secret && req.headers['x-backfill-secret'] !== secret) {
+    logger.warn('Unauthorized backfill attempt denied.');
+    res.status(403).send('Forbidden: Missing or invalid secret.');
+    return;
+  }
+
+  const db = getFirestore();
+
+  // Determine date range from query parameters or use defaults
+  const startDateParam = req.query.startDate as string;
+  const endDateParam = req.query.endDate as string;
+
+  // Validate or default dates
+  let startDateIso: string;
+  let endDateIso: string;
+  const now = new Date();
+  const defaultStartDate = new Date(2025, 0, 1); // January 1st, 2025
+
+  try {
+    startDateIso = startDateParam ? new Date(startDateParam + 'T00:00:00.000Z').toISOString() : defaultStartDate.toISOString();
+    endDateIso = endDateParam ? new Date(endDateParam + 'T23:59:59.999Z').toISOString() : now.toISOString();
+
+    if (new Date(endDateIso) < new Date(startDateIso)) {
+      throw new Error('End date cannot be before start date.');
+    }
+  } catch (e) {
+    logger.error('Invalid date format provided.', { startDateParam, endDateParam, error: e });
+    res.status(400).send(`Invalid date format. Use YYYY-MM-DD. Error: ${e.message}`);
+    return;
+  }
+
+  logger.info(`Starting goals backfill process for range: ${startDateIso} to ${endDateIso}`);
+
+  // Data structures for aggregation
+  const playerStats: { [playerId: string]: IPlayerGoalsAggregate } = {};
+  let totalMatchesProcessed = 0;
+  let lastMatchSnapshot: QueryDocumentSnapshot | null = null;
+
+  try {
+    // Fetch matches in batches
+    while (true) {
+      let query = db
+        .collection(MATCHES_COLLECTION)
+        .where('matchDate', '>=', startDateIso)
+        .where('matchDate', '<=', endDateIso)
+        .orderBy('matchDate', 'asc')
+        .limit(MATCH_FETCH_LIMIT);
+
+      if (lastMatchSnapshot) {
+        query = query.startAfter(lastMatchSnapshot);
+      }
+
+      const matchesSnapshot = await query.get();
+      if (matchesSnapshot.empty) {
+        logger.info('No more matches found in the date range for this iteration.');
+        break;
+      }
+
+      const matchesInBatch = matchesSnapshot.docs.length;
+      totalMatchesProcessed += matchesInBatch;
+      lastMatchSnapshot = matchesSnapshot.docs[matchesInBatch - 1];
+      logger.info(`Fetched ${matchesInBatch} matches (Total: ${totalMatchesProcessed}). Aggregating...`);
+
+      // Process Matches
+      for (const matchDoc of matchesSnapshot.docs) {
+        const matchResult = matchDoc.data() as IMatchResult;
+        if (!matchResult.matchDate || !matchResult.homeTeamIds || !matchResult.awayTeamIds || !matchResult.finalScore) {
+          logger.warn(`Skipping match ${matchDoc.id} due to missing data.`);
+          continue;
+        }
+
+        const allPlayerIds: string[] = [...matchResult.homeTeamIds, ...matchResult.awayTeamIds];
+
+        for (const playerId of allPlayerIds) {
+          if (!playerStats[playerId]) {
+            playerStats[playerId] = {
+              totalGoalsFor: 0,
+              totalGoalsAgainst: 0,
+            };
+          }
+
+          const { goalsFor, goalsAgainst } = calculatePlayerGoals(playerId, matchResult);
+          playerStats[playerId].totalGoalsFor += goalsFor;
+          playerStats[playerId].totalGoalsAgainst += goalsAgainst;
+
+          // Update last match date if this match is more recent
+          if (!playerStats[playerId].lastMatchDate || matchResult.matchDate > playerStats[playerId].lastMatchDate) {
+            playerStats[playerId].lastMatchDate = matchResult.matchDate;
+          }
+        }
+      }
+      logger.info(`Finished aggregating batch. Last match date: ${lastMatchSnapshot?.data().matchDate}`);
+    }
+
+    logger.info(`Finished processing all ${totalMatchesProcessed} matches for the range.`);
+
+    // Write aggregated data to Firestore
+    logger.info('Starting Firestore writes...');
+    const totalWrites = await writeGoalStatsToFirestore(db, playerStats);
+
+    // Send Success Response
+    const message = `Goals backfill successful for ${startDateIso} to ${endDateIso}. Processed ${totalMatchesProcessed} matches. Updated ${totalWrites} player documents.`;
+    logger.info(message);
+    res.status(200).send(message);
+  } catch (error: any) {
+    logger.error('Goals backfill failed:', error);
+    res.status(500).send(`Goals backfill failed: ${error.message}`);
+  }
+});

--- a/apps/sandbox/src/triggers/backfill-goals-stats.trigger.ts
+++ b/apps/sandbox/src/triggers/backfill-goals-stats.trigger.ts
@@ -122,6 +122,7 @@ export const backfillGoalsStats = onRequest(functionOptions, async (req, res): P
 
   try {
     // Fetch matches in batches
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       let query = db
         .collection(MATCHES_COLLECTION)

--- a/apps/sandbox/src/triggers/index.ts
+++ b/apps/sandbox/src/triggers/index.ts
@@ -1,2 +1,3 @@
 export * from './backfill-time-stats.trigger';
 export * from './sync-player-stats';
+export * from './backfill-goals-stats.trigger';

--- a/libs/common/src/player/player.interface.ts
+++ b/libs/common/src/player/player.interface.ts
@@ -7,6 +7,8 @@ export interface IPlayerStats {
   totalHumiliations?: number;
   totalSuckerpunches?: number;
   totalKnockouts?: number;
+  totalGoalsFor?: number;
+  totalGoalsAgainst?: number;
   dateLastMatch?: string;
   dateLastWin?: string;
   dateLastFlawlessVictory?: string;

--- a/libs/common/src/player/player.model.ts
+++ b/libs/common/src/player/player.model.ts
@@ -52,6 +52,12 @@ export class Player extends FirestoreDocument implements IPlayer {
   @serializable(numberMetric())
   totalKnockouts = 0;
 
+  @serializable(numberMetric())
+  totalGoalsFor = 0;
+
+  @serializable(numberMetric())
+  totalGoalsAgainst = 0;
+
   @serializable
   dateLastMatch?: string;
 

--- a/libs/common/src/statistics/metrics.interface.ts
+++ b/libs/common/src/statistics/metrics.interface.ts
@@ -8,6 +8,8 @@ export interface IMetrics {
   totalHumiliations?: number | admin.firestore.FieldValue;
   totalSuckerpunches?: number | admin.firestore.FieldValue;
   totalKnockouts?: number | admin.firestore.FieldValue;
+  totalGoalsFor?: number | admin.firestore.FieldValue;
+  totalGoalsAgainst?: number | admin.firestore.FieldValue;
   dateLastMatch?: string;
   dateLastWin?: string;
   dateLastFlawlessVictory?: string;


### PR DESCRIPTION
This pull request includes significant enhancements to the leaderboard and statistics functionalities, particularly focusing on the all-time leaderboard and player goal statistics. The most important changes include the addition of a new endpoint for the all-time leaderboard, the implementation of a backfill function for player goal statistics, and updates to the player and metrics interfaces to include goal statistics.

### Leaderboard Enhancements:
* Added `getAllTimeLeaderboard` function to fetch and rank players based on their all-time statistics in `leaderboards.controller.ts`.
* Introduced a new endpoint `/leaderboards/all-time` to retrieve the all-time leaderboard.

### Backfill Function for Player Goal Statistics:
* Implemented `backfillGoalsStats` cloud function to aggregate and update player goal statistics in Firestore.
* Exported the new backfill function in `index.ts`.

### Player and Metrics Interface Updates:
* Updated `IPlayerStats` and `IMetrics` interfaces to include `totalGoalsFor` and `totalGoalsAgainst` fields. [[1]](diffhunk://#diff-d3513c57882d3f452366b0da636f794f4605b6f52dda0f4338f4f5ab9a88f65bR10-R11) [[2]](diffhunk://#diff-1b0399a66f5128192cc639e2daf340d4cdc3cab999925f154fa434088aa2bfedR11-R12)
* Modified the `Player` model to include `totalGoalsFor` and `totalGoalsAgainst` fields.

### Stats Service Enhancements:
* Updated `calculateMetrics` method in `StatsService` to include goal statistics. [[1]](diffhunk://#diff-6c2ea1443324631e9ba519fb990280ce35b791a4992046bc03ae07f786cbccc0L109-R109) [[2]](diffhunk://#diff-6c2ea1443324631e9ba519fb990280ce35b791a4992046bc03ae07f786cbccc0L198-R211)