### PR TITLE
chore(firebase): upgrade firebase-functions to v7 (+ firebase-admin 13.8.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "@slack/web-api": "^7.15.0",
         "express": "4.22.1",
         "firebase": "^12.11.0",
-        "firebase-admin": "^13.7.0",
-        "firebase-functions": "^6.3.2",
+        "firebase-admin": "^13.8.0",
+        "firebase-functions": "^7.2.5",
         "luxon": "^3.7.2",
         "serializr": "^3.0.5",
         "tslib": "^2.3.0"
@@ -7384,6 +7384,7 @@
       "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
       "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -11019,9 +11020,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -11032,7 +11033,7 @@
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.4.0",
         "uuid": "^11.0.2"
       },
       "engines": {
@@ -11125,9 +11126,10 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.3.2.tgz",
-      "integrity": "sha512-FC3A1/nhqt1ZzxRnj5HZLScQaozAcFSD/vSR8khqSoFNOfxuXgwJS6ZABTB7+v+iMD5z6Mmxw6OfqITUBuI7OQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -11140,10 +11142,24 @@
         "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
-        "node": ">=14.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/firebase-functions-test": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@slack/web-api": "^7.15.0",
     "express": "4.22.1",
     "firebase": "^12.11.0",
-    "firebase-admin": "^13.7.0",
-    "firebase-functions": "^6.3.2",
+    "firebase-admin": "^13.8.0",
+    "firebase-functions": "^7.2.5",
     "luxon": "^3.7.2",
     "serializr": "^3.0.5",
     "tslib": "^2.3.0"


### PR DESCRIPTION
## Firebase Dependencies Upgrade

| Package | From | To | Type |
|---|---|---|---|
| `firebase-functions` | 6.3.2 | 7.2.5 | **major** |
| `firebase-admin` | 13.7.0 | 13.8.0 | minor |

### Why no source changes?

`firebase-functions` v7 is a major release, but the breaking changes target the legacy v1 API (`firebase-functions/<trigger-type>`). This codebase exclusively uses the v2 API:

- `firebase-functions/v2/https` — `onRequest`, `onCall`
- `firebase-functions/v2/firestore` — `onDocumentCreated`, etc.
- `firebase-functions/v2/options` — `setGlobalOptions`
- `firebase-functions/logger`, `firebase-functions/params`

These imports remain unchanged in v7.

### Validation
- ✅ Build: 7/7 projects pass
- ✅ Test: 7/7 projects pass
- ✅ Post-build `npm install` in `dist/apps/{api,sandbox,slack-webhook}` succeeds (Nx + nx-firebase known lockfile fix)

### Note on stacking
This PR is independent of the Nx 22.7.0 migration (#1190). Either order is fine to merge.