### PR TITLE
chore(deps): bundle dependabot minor+patch updates by dep type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,14 @@ updates:
     ignore:
       # For cypress, ignore all updates. Do manually instead.
       - dependency-name: 'cypress'
+    groups:
+      production-minor-patch:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      development-minor-patch:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
## Summary

Add minor+patch buckets per `dependency-type`. Foosball previously had **no groups at all**, so every dep update became its own PR. Preserves the `cypress` ignore, weekly Sunday schedule, and `target-branch: main`.

## Why

Mirrors the fix from `onlineoffers-v2#191`. With 27 vulnerability alerts and no grouping, the PR backlog grows quickly; recent batch left 3 stuck PRs (#1196 eslint major, #1183 TypeScript major, #1121 express conflicting since 2026-03-22). Bundling makes routine updates a single weekly merge instead of N separate ones.

## Strategy

- **Minor + patch updates → bundled** by `dependency-type` (production / development). One PR per bucket per week.
- **Major bumps → individual** (fall outside `update-types`), so they get manual review.

No `github-actions` ecosystem is configured — left alone (out of scope).

## Test plan

- [ ] Wait for next scheduled Dependabot run (Sunday 04:00 UTC) to verify bundling
- [ ] Verify majors still arrive as individual PRs
- [ ] Verify cypress remains ignored