### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: '0'
           persist-credentials: false
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
       - name: Check cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: node-cache
         with:
           path: '**/node_modules'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,17 +19,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: '0'
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
       - name: Check cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: node-cache
         with:
           path: '**/node_modules'


### PR DESCRIPTION
## Summary

GitHub forces Node 24 for JavaScript actions starting 2026-06-16 (Node 20 removed from runners 2026-09-16). The v4 majors of these actions still run on the deprecated Node 20 runtime:

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6 (keeps reading `.nvmrc` via `node-version-file`)
- `actions/cache` v4 → v5

Applied to both `ci.yml` and `nightly.yml`. `mansagroup/nrwl-nx-action@v3` (third-party) left as-is.

## Test plan

- [x] CI green on the bumped actions